### PR TITLE
Added pip installation instructions for CUDA 10.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,9 @@ pip install cupy-cuda100
 # For CUDA 10.1
 pip install cupy-cuda101
 
+# For CUDA 10.2
+pip install cupy-cuda102
+
 # Install CuPy from source
 pip install cupy
 </code></pre>


### PR DESCRIPTION
I noticed this was missing from the website but present on the github readme.